### PR TITLE
perf: re-use psn auth-token request

### DIFF
--- a/src/playstation/middleware.ts
+++ b/src/playstation/middleware.ts
@@ -4,10 +4,20 @@ import { getNpServiceName } from './util/platforms';
 
 const REFRESH_TOKEN = process.env.PLAYSTATION_REFRESH_TOKEN?.trim() ?? '';
 
-async function getAuth(): Promise<any> {
+let authPromise: Promise<psn.AuthTokensResponse> | null = null;
+
+async function getAuth(): Promise<psn.AuthTokensResponse> {
   if (!REFRESH_TOKEN) throw new Error('No refresh token provided.');
-  const auth = await psn.exchangeRefreshTokenForAuthTokens(REFRESH_TOKEN);
-  return auth;
+  if (!authPromise) {
+    authPromise = (async () => {
+      const authorization = await psn.exchangeRefreshTokenForAuthTokens(REFRESH_TOKEN);
+      return authorization;
+    })().catch((err) => {
+      authPromise = null;
+      throw err;
+    });
+  }
+  return authPromise;
 }
 
 export async function getProfile(


### PR DESCRIPTION
Instead of re-exchanging it for all sub-requests in the same serverless function call.

All sub-request should now use the same Promise (either in-flight or already resolved) and its corresponding access tokens. Greatly reducing the amount of auth overhead for larger serverless functions.